### PR TITLE
fixed schema to rollback a redundant migration and renamed trip_type …

### DIFF
--- a/db/migrate/20200824154417_add_columns_to_trip.rb
+++ b/db/migrate/20200824154417_add_columns_to_trip.rb
@@ -1,6 +1,6 @@
 class AddColumnsToTrip < ActiveRecord::Migration[6.0]
   def change
     add_column :trips, :wind_gusts, :integer
-    add_column :trips, :type, :string
+    add_column :trips, :trip_type, :string
   end
 end

--- a/db/migrate/20200824163040_add_wind_gusts_to_trips.rb
+++ b/db/migrate/20200824163040_add_wind_gusts_to_trips.rb
@@ -1,5 +1,0 @@
-class AddWindGustsToTrips < ActiveRecord::Migration[6.0]
-  def change
-    add_column :trips, :wind_gusts, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_24_163040) do
+ActiveRecord::Schema.define(version: 2020_08_24_154417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2020_08_24_163040) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "wind_gusts"
-    t.string "type"
+    t.string "trip_type"
     t.index ["user_id"], name: "index_trips_on_user_id"
   end
 


### PR DESCRIPTION
apparently "type" is a reserved term and wasn't accepted by our schema. Changed to trip_type
