### PR TITLE
changed the order of the links in the edit view

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -33,10 +33,9 @@
       <% end %>
 
 
-      <p> <%= link_to "Delete my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-      <%= link_to "Home", root_path %>
-      <%= link_to 'Download my trips data', export_path(format: "csv") %>
+      <p> <%= link_to "Home", root_path %><p>
+      <p><%= link_to 'Download my trips data', export_path(format: "csv") %><p>
+      <p> <%= link_to "Delete my account", registration_path(resource_name), data: { confirm: "This will delete your user account and all associated data. Please confirm by clicking OK" }, method: :delete %></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
I've adjusted the order of the links in the edit view; the "delete my account" section now is no longer so dangeroulsy close to "Home" 

![image](https://user-images.githubusercontent.com/48927644/91845781-10208580-ec5a-11ea-8f09-a2bcb4fc7eeb.png)
